### PR TITLE
Update manifest name

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,7 +67,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Gatsby Starter Blog`,
+        name: `The IIFE`,
         short_name: `GatsbyJS`,
         start_url: `/`,
         background_color: `#ffffff`,


### PR DESCRIPTION
Updates:
- replaces `Gatsby Starter Blog` with `The IIFE` for manifest